### PR TITLE
Add CODEOWNERS rule for /api/**

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+/api/** @backend-team


### PR DESCRIPTION
## Summary
- add a CODEOWNERS rule mapping `/api/**` to `@backend-team`
- create `.github/CODEOWNERS` for this rule
